### PR TITLE
Fixes node applications spinning whenever a port is in use.

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,8 +40,8 @@ module.exports = function(app, options) {
     }
 
     cluster.on('exit', function(worker, code, signal) {
-      logger.error(('worker ' + worker.process.pid + ' died').red + ', reforking...')
-      var worker = cluster.fork()
+      logger.error(('worker ' + worker.process.pid + ' died').red + ', exiting...')
+      process.exit();
     })
     
     var debug_mode = false


### PR DESCRIPTION
- exit the process instead of reforking on error

To test:
- NPM link the clustrap to a project using the HEAD revision of clustrap (i.e. shoebuy.api)
- run an instance of the API on port 3000
- try to run another instance of the API on port 3000
- note that the application exists instead of continually trying to refork
